### PR TITLE
Fix errors in deployment scripts

### DIFF
--- a/app/aeskeywrapper.py
+++ b/app/aeskeywrapper.py
@@ -87,13 +87,12 @@ class AESKeyWrapper:
 import random, string
 from config import Config
 
-config = Config()
-
 def generate_aes_key(length):
     letters = string.ascii_lowercase
     return ''.join(random.choice(letters) for i in range(length))
 
 if __name__ == "__main__":
+    config = Config()
     wrapper = AESKeyWrapper(vault = '',
                             client_id = '',
                             secret = '',
@@ -107,9 +106,9 @@ if __name__ == "__main__":
         key = generate_aes_key(32)
         wrapped_key = wrapper.wrap_aes_key_local(key, public_key)
         restored_aes_key = wrapper.unwrap_aes_key(wrapped_key)
-        if key != restored_aes_key.result:
+        if key != restored_aes_key:
             print("==========================")
             print(key)
             print("--------------------------")
-            print(restored_aes_key.result)
+            print(restored_aes_key)
             print("")

--- a/app/processorconfiguration.py
+++ b/app/processorconfiguration.py
@@ -8,6 +8,7 @@ Steps:
 from azure.storage.blob import BlockBlobService
 from config import Config
 import os
+import base64
 
 # Config file is stored in /var/lib/waagent/CustomData
 # File is base64 encoded


### PR DESCRIPTION
1. don't instantiate config outside of main function
2. unwrap function returns result, not an object
3. import base64