### PR TITLE
Fix how we encode results and append to the consolidation blob

### DIFF
--- a/app/validator.py
+++ b/app/validator.py
@@ -100,8 +100,8 @@ class Validator(object):
                 # validate job processing health using the job status collection
                 self.validate_job_health(jobKey, redis_conn)
 
-                # consolidate any completed results
-                self.results.consolidate_results()
+        # consolidate any completed results
+        self.results.consolidate_results()
 
 def init_logging():
     """

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,6 +29,18 @@ services:
       - ./app:/usr/src/app
       - ./data:/usr/src/data
       - ./config:/usr/src/config
+  validator:
+    container_name: validator
+    build: ./docker-files/python27
+    working_dir: /usr/src
+    environment:
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+    command: python app/validator.py --redisHost redis
+    volumes:
+      - ./app:/usr/src/app
+      - ./data:/usr/src/data
+      - ./config:/usr/src/config
     depends_on:
       - redis
   dashboard:

--- a/samples/readFinalResults.py
+++ b/samples/readFinalResults.py
@@ -1,0 +1,31 @@
+"""
+    Simple class that reads in the results file, decodes each lines, and prints the results
+"""
+import base64
+import io
+import sys
+from app.aeshelper import AESHelper
+from app.config import Config
+from azure.storage.blob import BlockBlobService
+
+if __name__ == "__main__":
+    config = Config()
+    aes_helper = AESHelper(config)
+
+    aes_cipher = aes_helper.create_aescipher_from_config()
+
+    storage_service = BlockBlobService(account_name = config.storage_account_name, sas_token = config.results_container_sas_token)
+
+    results = []
+    with io.BytesIO() as blobContents:
+        storage_service.get_blob_to_stream(config.results_container, config.results_consolidated_file, blobContents)
+        blobContents.seek(0)
+
+        for result in blobContents.readlines():
+            decoded = aes_cipher.decrypt(base64.b64decode(result))
+            print 'encoded: ' + result + ' decoded: '  + decoded
+            results.append(decoded)
+
+    results.sort()
+    print results
+    print len(results)


### PR DESCRIPTION
Results.py
- We want to encode the encrypted result, not the other way around
- After reading the result blob as a stream, we need to reset the location in the buffer to write the result to the consolidated blob

validator.py
- We want to consolidate results every time the validator runs, because it is independent of the active jobs

docker-compose.yaml
- add a validator container

I also added a simple script print out the consolidated final results